### PR TITLE
Fix #10: Add explicit git config instructions to prevent wrong commit authors

### DIFF
--- a/github_agent.py
+++ b/github_agent.py
@@ -655,6 +655,17 @@ Respond with a comment on the issue addressing their request. Use `gh issue comm
         Clone repo to: {self.work_dir}/{repo}
         Create workspace for your changes: {self.work_dir}/{issue["number"]}_{repo.split('/')[1]}
 
+        CRITICAL - Git Configuration:
+        After cloning the repo, you MUST configure git identity BEFORE making any commits:
+        ```
+        cd {self.work_dir}/{repo}
+        git config user.email "${{GIT_USER_EMAIL:-${{GITHUB_USERNAME}}@users.noreply.github.com}}"
+        git config user.name "${{GITHUB_USERNAME}}"
+        git config user.name  # Verify it's set correctly
+        git config user.email  # Verify it's set correctly
+        ```
+        NEVER commit without first verifying the git config shows the correct username and email.
+
         Use `gh` CLI for GitHub operations:
         - gh issue view {issue["number"]} - to see issue details
         - gh issue comment {issue["number"]} --body "..." - to comment

--- a/prompts/github_agent_system_prompt.j2
+++ b/prompts/github_agent_system_prompt.j2
@@ -43,9 +43,15 @@ You are OpenHands GitHub Agent, an autonomous bot that manages GitHub repositori
 * Commit with descriptive messages: "Fix #{number}: {short description}"
 * Push branches and create PRs automatically
 * Use the configured GitHub credentials for authentication
-* Configure git identity before committing using your GitHub username:
-  - git config --global user.email "${GIT_USER_EMAIL:-${GITHUB_USERNAME}@users.noreply.github.com}"
-  - git config --global user.name "${GITHUB_USERNAME}"
+* CRITICAL: Configure git identity BEFORE any git operations (clone, commit, push):
+  - After cloning a repo, immediately run these commands in the repo directory:
+    ```
+    git config user.email "${GIT_USER_EMAIL:-${GITHUB_USERNAME}@users.noreply.github.com}"
+    git config user.name "${GITHUB_USERNAME}"
+    ```
+  - This ensures ALL commits use the correct author identity
+  - NEVER commit without first verifying git config with `git config user.name` and `git config user.email`
+  - The local repo config overrides global config, so ALWAYS configure git in the repo directory
 * If you don't have write access to a repo, fork first: gh repo fork {owner}/{repo} --clone=true
 * Always push to your fork if you don't have write access, then create a PR from the fork
 * IMPORTANT: If `git push` fails with permission error:


### PR DESCRIPTION
## Summary
This fix addresses the issue where the agent was creating commits with random/incorrect usernames instead of the configured GitHub user.

The root cause was that the agent wasn't consistently configuring git in the local repo directory after cloning. Global git config can be overridden by local repo config, so we now explicitly instruct the agent to set git config in each repo it works on.

## Changes Made
- Updated system prompt (`prompts/github_agent_system_prompt.j2`): Added CRITICAL instructions about configuring git identity BEFORE any git operations, emphasizing that local repo config overrides global config
- Updated issue prompt builder (`github_agent.py`): Added explicit git configuration commands that must be run after cloning a repo, with verification steps

## Testing
The fix adds instructions to the agent's prompts. Future commits made by the agent should now use the correct username and email as configured.

Closes #10
